### PR TITLE
Ensure Next.js commands run from project root

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "dev": "next dev -p 3000",
-    "build": "next build",
-    "start": "next start -p 3000"
+    "dev": "node scripts/run-next.cjs dev -p 3000",
+    "build": "node scripts/run-next.cjs build",
+    "start": "node scripts/run-next.cjs start -p 3000"
   },
   "dependencies": {
     "next": "14.2.5",

--- a/web/scripts/run-next.cjs
+++ b/web/scripts/run-next.cjs
@@ -1,0 +1,33 @@
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const [, , command, ...restArgs] = process.argv;
+
+if (!command) {
+  console.error('Usage: node scripts/run-next.cjs <command> [...args]');
+  process.exit(1);
+}
+
+const projectRoot = path.resolve(__dirname, '..');
+process.chdir(projectRoot);
+
+const isWindows = process.platform === 'win32';
+const nextExecutable = path.join(
+  projectRoot,
+  'node_modules',
+  '.bin',
+  `next${isWindows ? '.cmd' : ''}`
+);
+
+const child = spawn(nextExecutable, [command, ...restArgs], {
+  stdio: 'inherit',
+  shell: isWindows
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
## Summary
- add a helper script that forces Next.js CLI commands to execute from the web app directory, even when the shell falls back to another location (e.g. UNC paths on Windows)
- update npm scripts to invoke the helper so dev/build/start succeed on Windows

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d36c57bb4c8333a49bd00fd64b8946